### PR TITLE
VHDL_LS: vhdl_ls-aarch64-apple-darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Extension is maintained by Jakob Jungreuthmayer, Sonja Schoissengaier and F
 
 ## Technology
 This extension is based on the [VHDL-LS](https://github.com/VHDL-LS/rust_hdl#vhdl-language-server) Language Server. 
-Pre-compiled binaries for Linux and Windows are provided with the extension.
+Pre-compiled binaries for Linux, Windows and MacOS are provided with the extension.
 
 The server can also be loaded from either the system path or Docker depending
 on the value of the `vhdl-by-hgb.vhdlls.languageServer` property.
@@ -99,6 +99,8 @@ UNISIM.is_third_party = true
 - Renaming symbols
 - Finding workspace symbols
 - Viewing/finding document symbols
+- Code-Completion:
+	- Entity
 
 ## Formatting
 
@@ -206,6 +208,9 @@ This can be done by:
 The generated snippets can be used by typing `entity`.<!--`ei_${entity-name}`.-->
 
 The Snippet format is `entity {entity-name} - instantiation`.
+
+(**Note:** This feature was developed before [VHDL-LS](https://github.com/VHDL-LS/rust_hdl#vhdl-language-server) supported entity-completion. From now on, it serves as an alternative.)
+
 
 ## Entity-Converter
 

--- a/src/features/utils/hdl/general/hdl_utils.ts
+++ b/src/features/utils/hdl/general/hdl_utils.ts
@@ -42,7 +42,7 @@ export class HDLUtils {
         const implementation = await vscode.commands.executeCommand<vscode.Location[]>(
             'vscode.executeImplementationProvider',
             vscode.Uri.file(filePath),
-            entitySymbol?.range.start
+            entitySymbol?.selectionRange.start
         );
 
         // check for valid implementation-file


### PR DESCRIPTION
+ VHDL_LS now supports macOS (only 64-Bit ARM-CPUs(M1, M2, M3...) -> no support for older apple-devices with x86-64-CPU !)
+ README: updates for MacOS and Code-Completion from VHDL_LS
+ hdl_utils: goto/Implementation -> use selectionRange instead of range