### PR TITLE
bug-fix: EntityConverter.PasteSignals

### DIFF
--- a/src/features/editor/entity_utils/entity_converter.ts
+++ b/src/features/editor/entity_utils/entity_converter.ts
@@ -45,7 +45,7 @@ export class EntityConverter {
         disposable = vscode.commands.registerCommand('VHDLbyHGB.pasteAsEntity', () => this.pasteAsEntity());
         this.mContext.subscriptions.push(disposable);
 
-        disposable = vscode.commands.registerCommand('VHDLbyHGB.pasteSignals', () => this.pasteSignals);
+        disposable = vscode.commands.registerCommand('VHDLbyHGB.pasteSignals', () => this.pasteSignals());
         this.mContext.subscriptions.push(disposable);
 
         disposable = vscode.commands.registerCommand('VHDLbyHGB.pasteConstants', () => this.pasteConstants());


### PR DESCRIPTION
+ added round bracket for function "pasteSignals()" at registration of corresponding command