### PR TITLE
toml: third-party-libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ On Windows machines, use the `%NAME%` syntax to substitute environment variables
 
 	#### options
 	- `vhdl-by-hgb.vhdlls.toml.auto.exclude`: array of file-extensions to exclude from an auto-generated `vhdl_ls.toml`.
+	- `vhdl-by-hgb.vhdlls.toml.auto.third-party-libraries`: array of libraries to be marked as third-party in an auto-generated `vhdl_ls.toml`.
 
 ### manual 
 - `vhdl_ls.toml` must be generated manually by user e.g. via a custom python-script

--- a/package.json
+++ b/package.json
@@ -535,6 +535,11 @@
                     "type": "array",
                     "default": [".v", ".vh", ".sv", ".svh"]
                 },
+                "vhdl-by-hgb.vhdlls.toml.auto.third-party-libraries": {
+                    "description": "libraries to be marked as third-party in an auto-generated vhdl_ls.toml-file",
+                    "type": "array",
+                    "default": ["bitvis", "hdl-modules", "neorv", "olo", "osvvm", "PoC", "surf", "uvvm", "vunit_lib"]
+                },
                 "vhdl-by-hgb.python": {
                     "title": "Python executable",
                     "description": "Path to python executable",

--- a/src/features/lsp/vhdl_ls_package.ts
+++ b/src/features/lsp/vhdl_ls_package.ts
@@ -3,30 +3,5 @@
 export namespace vhdl_ls
 {
     export const VHDL_LS_FILE = "vhdl_ls.toml";
-
-    export enum third_party_libraries {
-        VUnit = "vunit_lib",
-        OSVVM = "osvvm",
-        UVVM = "uvvm",
-        Bitvis = "bitvis",
-        PoC = "PoC",
-        NEORV = "neorv",
-    }
-
-    export function is_third_party_library(libraryName : string) : boolean
-    {
-        const third_party_libs = Object.values(vhdl_ls.third_party_libraries) as string[];
-
-        for (const third_party_lib of third_party_libs)
-        {
-            if (libraryName.includes(third_party_lib))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
 }
 

--- a/src/features/project/project_manager.ts
+++ b/src/features/project/project_manager.ts
@@ -281,11 +281,24 @@ function filter_files(projectFiles : VhdlProjectFiles)
 
 function mark_third_party_libraries(projectFiles : VhdlProjectFiles)
 {
+    const third_party_libraries = vscode.workspace.getConfiguration().get("vhdl-by-hgb.vhdlls.toml.auto.third-party-libraries") as string[] | undefined;
+
+    if (!third_party_libraries) {
+        return;
+    }
+
+    if (third_party_libraries.length < 1) {
+        return;
+    }
+
     for (const [libraryName, libraryContents] of projectFiles.entries())
     {
-        if (vhdl_ls.is_third_party_library(libraryName))
+        for (const third_party_lib of third_party_libraries)
         {
-            projectFiles.get(libraryName)!.is_third_party = true;
+            if (libraryName.includes(third_party_lib))
+            {
+                libraryContents.is_third_party = true;
+            }
         }
     }
 }


### PR DESCRIPTION
+ mark certain libraries as third-party in an auto-generated `vhdl_ls.toml`. third-party-libraries can be specified via a configuration-property. default-values are some of the biggest open-source-vhdl-libraries.